### PR TITLE
Update .addon to specify root namespace

### DIFF
--- a/.addon
+++ b/.addon
@@ -1,4 +1,5 @@
 {
     "sharedassets": "*.*",
-    "type": "game"
+    "type": "game",
+    "rootnamespace": "MinimalExample"
 }


### PR DESCRIPTION
Adds new `rootnamespace` field to .addon file.

This prevents an invalid root namespace name when downloading from zip (currently defaults to `sbox-minimal-master`) and when cloning directly (defaulting to `sbox-minimal`).